### PR TITLE
fix: remove Backpack wallet adapter reference

### DIFF
--- a/src/components/SolanaWalletProvider.tsx
+++ b/src/components/SolanaWalletProvider.tsx
@@ -22,9 +22,8 @@ export const SolanaWalletProvider: FC<SolanaWalletProviderProps> = ({ children }
     () => [
       new PhantomWalletAdapter(),
       new SolflareWalletAdapter(),
-      new BackpackWalletAdapter(),
     ],
-    [network]
+    []
   );
 
   return (


### PR DESCRIPTION
## Summary
- remove unsupported Backpack wallet adapter from Solana wallet provider
- keep Phantom and Solflare adapters only

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689247906b80832c833877f9c28c4419