### PR TITLE
refactor: remove explicit wallet adapters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/src/components/SolanaWalletProvider.tsx
+++ b/src/components/SolanaWalletProvider.tsx
@@ -1,7 +1,6 @@
 import { FC, ReactNode, useMemo } from 'react';
 import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';
 import { WalletModalProvider } from '@solana/wallet-adapter-react-ui';
-import { PhantomWalletAdapter,  SolflareWalletAdapter } from '@solana/wallet-adapter-wallets';
 import { WalletAdapterNetwork } from '@solana/wallet-adapter-base';
 import { clusterApiUrl } from '@solana/web3.js';
 
@@ -17,14 +16,8 @@ export const SolanaWalletProvider: FC<SolanaWalletProviderProps> = ({ children }
   const network = WalletAdapterNetwork.Devnet;
   const endpoint = useMemo(() => clusterApiUrl(network), [network]);
 
-  // Initialize supported wallets
-  const wallets = useMemo(
-    () => [
-      new PhantomWalletAdapter(),
-      new SolflareWalletAdapter(),
-    ],
-    []
-  );
+  // Initialize supported wallets (rely on standard wallet detection)
+  const wallets = useMemo(() => [], []);
 
   return (
     <ConnectionProvider endpoint={endpoint}>


### PR DESCRIPTION
## Summary
- rely on wallet standard detection instead of hardcoded Phantom/Solflare adapters
- ignore build and dependency directories

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react"; attempted install but received 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68924eed01bc832c8d1784f3543a2a70