### PR TITLE
fix: export initialize tournaments

### DIFF
--- a/src/lib/tournament.ts
+++ b/src/lib/tournament.ts
@@ -332,3 +332,8 @@ export class TournamentManager {
     }
   }
 }
+
+// Convenience function to initialize tournaments without accessing the manager directly
+export function initializeTournaments(): void {
+  TournamentManager.initializeTournaments();
+}


### PR DESCRIPTION
## Summary
- expose initializeTournaments helper from tournament manager
- call initializeTournaments on index page to set up tournaments
- optimize card layout with responsive columns and larger visuals

## Testing
- `pnpm lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68929940a38c832c9f3bba999d7a8d73